### PR TITLE
Cancel delete automatically returns the item to list.

### DIFF
--- a/app/src/main/java/ca/outercove/uomiapplication/fragments/AccountsViewFragment.java
+++ b/app/src/main/java/ca/outercove/uomiapplication/fragments/AccountsViewFragment.java
@@ -107,6 +107,7 @@ public class AccountsViewFragment extends Fragment {
                 DialogFragment newFrag = DeleteAccountDialogFragment.newInstance(
                         R.string.delete_account);
                 newFrag.show(getFragmentManager(), "dialog");
+                ((DeleteAccountDialogFragment) newFrag).setAdapter(mAdapter);
             }
         }).attachToRecyclerView(recyclerView);
         return view;

--- a/app/src/main/java/ca/outercove/uomiapplication/fragments/DeleteAccountDialogFragment.java
+++ b/app/src/main/java/ca/outercove/uomiapplication/fragments/DeleteAccountDialogFragment.java
@@ -17,6 +17,8 @@ import ca.outercove.uomiapplication.listAdapters.AccountsViewListAdapter;
 public class DeleteAccountDialogFragment extends DialogFragment {
 
 
+    private AccountsViewListAdapter adapter;
+
     @Override
         public Dialog onCreateDialog(Bundle savedInstanceState) {
             AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
@@ -36,6 +38,7 @@ public class DeleteAccountDialogFragment extends DialogFragment {
                         @Override
                         public void onClick(DialogInterface dialog, int which) {
                             DeleteAccountDialogFragment.this.getDialog().cancel();
+                            adapter.notifyDataSetChanged();
                         }
                     });
 
@@ -55,6 +58,11 @@ public class DeleteAccountDialogFragment extends DialogFragment {
          */
         public DeleteAccountDialogFragment() {
 
+        }
+
+        //Takes the adapter for Accounts view Fragment
+        public void setAdapter(AccountsViewListAdapter adapter) {
+            this.adapter = adapter;
         }
 
 }

--- a/app/src/main/java/ca/outercove/uomiapplication/fragments/DeleteTransactionDialogFragment.java
+++ b/app/src/main/java/ca/outercove/uomiapplication/fragments/DeleteTransactionDialogFragment.java
@@ -9,12 +9,16 @@ import android.support.v4.app.DialogFragment;
 import android.view.LayoutInflater;
 
 import ca.outercove.uomiapplication.R;
+import ca.outercove.uomiapplication.listAdapters.TransactionsListAdapter;
 
 /**
  * Dialog Fragment for deleting a transaction. This is shown when you swipe right on an transaction.
  *
  */
 public class DeleteTransactionDialogFragment extends DialogFragment {
+
+    private TransactionsListAdapter adapter;
+
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
@@ -34,6 +38,7 @@ public class DeleteTransactionDialogFragment extends DialogFragment {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
                         DeleteTransactionDialogFragment.this.getDialog().cancel();
+                        adapter.notifyDataSetChanged();
                     }
                 });
 
@@ -55,4 +60,8 @@ public class DeleteTransactionDialogFragment extends DialogFragment {
 
     }
 
+    //Takes the adapter for SingleAccountFragment
+    public void setAdapter(TransactionsListAdapter adapter) {
+        this.adapter = adapter;
+    }
 }

--- a/app/src/main/java/ca/outercove/uomiapplication/fragments/SingleAccountFragment.java
+++ b/app/src/main/java/ca/outercove/uomiapplication/fragments/SingleAccountFragment.java
@@ -121,6 +121,7 @@ public class SingleAccountFragment extends Fragment {
                 DialogFragment newFrag = DeleteTransactionDialogFragment.newInstance(
                         R.string.delete_transaction);
                 newFrag.show(getFragmentManager(), "dialog");
+                ((DeleteTransactionDialogFragment) newFrag).setAdapter(mAdapter);
             }
         }).attachToRecyclerView(recyclerView);
         return view;


### PR DESCRIPTION
- Swipe to delete cancel on transactions/accounts will automatically bring back the item. No longer need to refresh list manually by exiting and re-entering. 

