### PR TITLE
Transaction Payer Name and Transaction Add bug fix

### DIFF
--- a/app/src/main/java/ca/outercove/uomiapplication/MainActivity.java
+++ b/app/src/main/java/ca/outercove/uomiapplication/MainActivity.java
@@ -121,9 +121,10 @@ CreateAccountFragment.OnFragmentInteractionListener {
     }
 
     @Override
-    public void onFragmentInteraction(Integer accId) {
+    public void onFragmentInteraction(Integer accId, String otherAccountUsers) {
         Bundle bundle = new Bundle();
         bundle.putInt("accountId", accId);
+        bundle.putString("otherAccountUsers", otherAccountUsers);
         mNavController.navigate(R.id.postTransactionCreation, bundle);
     }
 

--- a/app/src/main/java/ca/outercove/uomiapplication/fragments/AccountsViewFragment.java
+++ b/app/src/main/java/ca/outercove/uomiapplication/fragments/AccountsViewFragment.java
@@ -97,8 +97,6 @@ public class AccountsViewFragment extends Fragment
         recyclerView.setLayoutManager(new LinearLayoutManager(context));
         this.pref = PreferenceManager.getDefaultSharedPreferences(getContext());
         getUserAccounts();
-        //mAdapter = new AccountsViewListAdapter(AccountsViewContent.ITEMS, mListener);
-        //recyclerView.setAdapter(mAdapter);
 
         new ItemTouchHelper(new ItemTouchHelper.SimpleCallback(0,
                 ItemTouchHelper.LEFT) {

--- a/app/src/main/java/ca/outercove/uomiapplication/fragments/CreateTransactionFragment.java
+++ b/app/src/main/java/ca/outercove/uomiapplication/fragments/CreateTransactionFragment.java
@@ -125,7 +125,7 @@ public class CreateTransactionFragment extends Fragment {
             @Override
             public void onResponse(JSONObject response) {
                 if (mListener != null) {
-                    mListener.onFragmentInteraction(accountId);
+                    mListener.onFragmentInteraction(accountId, getArguments().getString("accUsers"));
                 }
             }
         }, new Response.ErrorListener() {
@@ -170,6 +170,6 @@ public class CreateTransactionFragment extends Fragment {
      */
     public interface OnFragmentInteractionListener {
         // TODO: Update argument type and name
-        void onFragmentInteraction(Integer accountId);
+        void onFragmentInteraction(Integer accountId, String otherAccountUsers);
     }
 }

--- a/app/src/main/java/ca/outercove/uomiapplication/fragments/SingleAccountFragment.java
+++ b/app/src/main/java/ca/outercove/uomiapplication/fragments/SingleAccountFragment.java
@@ -109,10 +109,6 @@ public class SingleAccountFragment extends Fragment
         recyclerView = view.findViewById(R.id.transactionsRecView);
         recyclerView.setLayoutManager(new LinearLayoutManager(context));
         getSingleAccountInformation();
-//        mAdapter = new TransactionsListAdapter(SingleAccountViewContent.ITEMS, mListener);
-//        recyclerView.setAdapter(mAdapter);
-
-
 
         new ItemTouchHelper(new ItemTouchHelper.SimpleCallback(0,
                 ItemTouchHelper.LEFT) {

--- a/app/src/main/java/ca/outercove/uomiapplication/fragments/SingleAccountFragment.java
+++ b/app/src/main/java/ca/outercove/uomiapplication/fragments/SingleAccountFragment.java
@@ -33,6 +33,7 @@ import org.json.JSONObject;
 import java.util.ArrayList;
 
 import androidx.navigation.Navigation;
+import ca.outercove.uomiapplication.FormattingHelper;
 import ca.outercove.uomiapplication.R;
 import ca.outercove.uomiapplication.backendCommunication.RequestQueueSingleton;
 import ca.outercove.uomiapplication.listAdapters.TransactionsListAdapter;
@@ -99,6 +100,7 @@ public class SingleAccountFragment extends Fragment
             public void onClick(View v) {
                 Bundle bundle = new Bundle();
                 bundle.putInt("accountId", getArguments().getInt("accountId"));
+                bundle.putString("accUsers", getArguments().getString("otherAccountUsers"));
                 Navigation.findNavController(v).navigate(R.id.actionCreateTransaction, bundle);
             }
         });
@@ -179,7 +181,7 @@ public class SingleAccountFragment extends Fragment
                         // TODO: more meaningful payer info than just the user ID
                         TransactionItem newItem = new TransactionItem(
                                 transItem.getInt("transaction_id"), transItem.getString("trans_label"),
-                                String.valueOf(transItem.getInt("user_owed")) + " paid",
+                                String.valueOf(transItem.getString("user_owed_name")) + " paid",
                                 transItem.getDouble("amount")
                         );
                         transactionItemArrayList.add(newItem);


### PR DESCRIPTION
Transaction item now displays the name of the person who paid for it. Also, fixed a bug that wouldn't display the names of other users in the account when returning from creating a new transaction for the account